### PR TITLE
Clean code

### DIFF
--- a/R/convert_xls_as_xlsx.R
+++ b/R/convert_xls_as_xlsx.R
@@ -1,129 +1,95 @@
 library(fs)
 library(kwb.utils)
 
-get_excelcnv_exe <- function(
-  office_folder = kwb.utils::safePath("C:/Program Files (x86)/Microsoft Office")
-)
+# get_excelcnv_exe -------------------------------------------------------------
+get_excelcnv_exe <- function(office_folder = safe_office_folder())
 {
-  paths <- normalizePath(list.files(
-    office_folder, "excelcnv.exe", recursive = TRUE, full.names = TRUE
-  ))
+  x <- office_folder
   
-  n_files <- length(paths)
-  if (n_files == 0) {
+  paths <- list.files(x, "excelcnv.exe", recursive = TRUE, full.names = TRUE)
+  
+  if ((n <- length(paths)) == 0) {
     
-    stop(
-      "Excel conversion tool 'excelcnv.exe' not found under: ", office_folder
-    )
+    stop("Excel conversion tool 'excelcnv.exe' not found under: ", x)
   }
   
-  if (n_files > 1) {
+  if (n > 1) {
     
     # Sort (in case of multiple executables newest is at index 1)
     paths <- sort(paths, decreasing = TRUE)
     
-    cat(paste0(
-      "Found ", n_files, "versions of 'excelcnv.exe':\n  ",
-      kwb.utils::collapsed(paths, "\n  "),
-      "\nUsing the latest one:", paths[1]
-    ))
+    cat(
+      "Found", n, "versions of 'excelcnv.exe':\n ", 
+      kwb.utils::collapsed(paths, "\n "), "\nUsing the latest one:", paths[1]
+    )
   }
   
   paths[1]
 }
 
-
-delete_registry <- function(
-  office_folder = kwb.utils::safePath("C:/Program Files (x86)/Microsoft Office"),
-  dbg = TRUE) {
-
-  office_path_split <- strsplit(dirname(get_excelcnv_exe(office_folder)),
-                                split = "/")[[1]]
-  
-  
-  office_version <- sprintf("%s.0", 
-                            stringr::str_extract(office_path_split[length(office_path_split)],
-                                                 pattern = "[1][0-9]"))
-  
-  ### Delete registry entry:
-  ### http://justgeeks.blogspot.com/2014/08/free-convert-for-excel-files-xls-to-xlsx.html
-  
-  reg_entry <- paste0("HKEY_CURRENT_USER\\Software\\", 
-                      "Microsoft\\Office\\", 
-                       office_version, 
-                       "\\Excel\\Resiliency\\StartupItems")
-  
-  
-  cmd_delete_registry <- sprintf('reg delete %s /f', reg_entry)
-  
-  if(dbg) {
-    cat(sprintf("Deleting registry entry:\n%s", 
-                cmd_delete_registry))  
-    
-  }
-  
-  system(command = cmd_delete_registry)
-  
-  
+# safe_office_folder -----------------------------------------------------------
+safe_office_folder <- function()
+{
+  kwb.utils::safePath("C:/Program Files (x86)/Microsoft Office")
 }
 
+# delete_registry --------------------------------------------------------------
+delete_registry <- function(office_folder = safe_office_folder(), dbg = TRUE) 
+{
+  exe_path <- get_excelcnv_exe(office_folder)
+  
+  parent_folder <- basename(dirname(exe_path))
+
+  # Delete registry entry: 
+  # http://justgeeks.blogspot.com/2014/08/
+  # free-convert-for-excel-files-xls-to-xlsx.html
+
+  patterns <- list(
+    office = "HKEY_CURRENT_USER\\Software\\Microsoft\\Office",
+    reg_entry = "<office>\\<version>.0\\Excel\\Resiliency\\StartupItems",
+    command = "reg delete <reg_entry> /f",
+    debug = "Deleting registry entry:\n<command>",
+    version = stringr::str_extract(parent_folder, pattern = "[1][0-9]")
+  )
+  
+  kwb.utils::catIf(dbg, kwb.utils::resolve("debug", patterns))
+
+  system(command = command)
+}
 
 ### Convert xls to xlsx in temp dir
 
 convert_xls_as_xlsx <- function(
-  input_dir = "Y:/Z-Exchange/Jeansen/Daten_Labor",
-  export_dir = tempdir(), 
-  office_folder = kwb.utils::safePath("C:/Program Files (x86)/Microsoft Office"),
-  dbg = TRUE) {
-
-
-pattern <- "\\.([xX][lL][sS])$"
-
-input_dir <- normalizePath(input_dir)
-
-export_dir <- normalizePath(export_dir)
-
-
-xls_files <-  normalizePath(dir(path = input_dir, 
-                  pattern = pattern, 
-                  recursive = TRUE, 
-                  full.names = TRUE))
-
-
-xlsx_files <- gsub(pattern = input_dir, 
-                   replacement = export_dir, 
-                   x = xls_files,
-                   fixed = TRUE)
-
-xlsx_files <- gsub(pattern = pattern, 
-                   replacement = ".xlsx", 
-                   x = xlsx_files)
-
-
-fs::dir_create(path = normalizePath(dirname(xlsx_files)),
-               recursive = TRUE) 
-
-
-for (index in seq_along(xls_files)) {
+  input_dir = "Y:/Z-Exchange/Jeansen/Daten_Labor", 
+  export_dir = tempdir(), office_folder = safe_office_folder(), dbg = TRUE
+) 
+{
+  input_dir <- normalizePath(input_dir)
   
-  cmd <- sprintf('"%s" -oice "%s" "%s"',
-                 get_excelcnv_exe(office_folder),
-                 xls_files[index],
-                 xlsx_files[index])
+  export_dir <- normalizePath(export_dir)
   
-  if(dbg) {
-  cat(sprintf("Converting xls to xlsx (%d/%d):\n%s", 
-                index, 
-                length(xls_files),
-                cmd))
-  } 
+  pattern <- "\\.([xX][lL][sS])$"
   
-  system(command = cmd)
-  delete_registry(office_folder = office_folder,
-                  dbg = dbg)
+  xls_files <- dir(input_dir, pattern, recursive = TRUE, full.names = TRUE)
+
+  xlsx_files <- gsub(input_dir, export_dir, xls_files, fixed = TRUE)
   
+  xlsx_files <- gsub(pattern, ".xlsx", xlsx_files)
+
+  fs::dir_create(path = normalizePath(dirname(xlsx_files)), recursive = TRUE) 
+
+  exe <- get_excelcnv_exe(office_folder)
+  
+  for (i in seq_along(xls_files)) {
+
+    command <- sprintf('"%s" -oice "%s" "%s"', exe, xls_files[i], xlsx_files[i])
+    
+    kwb.utils::catIf(dbg, sprintf(
+      "Converting xls to xlsx (%d/%d):\n%s", i, length(xls_files), command
+    ))
+
+    system(command)
+    
+    delete_registry(office_folder, dbg = dbg)
+  }
 }
-
-
-}
-


### PR DESCRIPTION
Hi Michael, 

I cleaned the code in file convert_xls_as_xlsx.R. Would you like to pull?
Changes:
- DRY -> new function safe_office_folder()
- shorter names -> single lines instead of multi-lines
- cat() already does paste()
- compose command with grammar definition and
  kwb.utils::resolve()
- use kwb.utils::catIf() to save lines and braces
- normalizePath() not necessary after dir() (?)